### PR TITLE
Flexible Docker images/Raspberry Pi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,10 @@ docker build --file ./docker/freqtrade/Dockerfile --tag ph3nol/freqtrade:latest 
 docker build --file ./docker/freqtrade-ui/Dockerfile --tag ph3nol/freqtrade-ui:latest .
 docker build --file ./docker/manager/Dockerfile --tag ph3nol/freqtrade-manager:latest .
 ```
+### Build Docker images (Raspberry Pi)
+
+```
+docker build --file ./docker/freqtrade_pi/Dockerfile --tag ph3nol/freqtrade:latest-pi .
+docker build --file ./docker/freqtrade-ui/Dockerfile --tag ph3nol/freqtrade-ui:latest-pi .
+docker build --file ./docker/manager/Dockerfile --tag ph3nol/freqtrade-manager:latest-pi .
+```

--- a/bot
+++ b/bot
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 
@@ -22,6 +22,13 @@ fi
 if [ ! -f "${BOT_CONFIG_DIRECTORY}/manager.yaml" ]; then
     e_error "You seem not to be into a Freqtrade Manager working directory. Please take a look at the documentation."
     exit
+fi
+
+arch=`uname -m`
+if [ $arch = 'armv7l' ]; then
+    DOCKER_TAG="ph3nol/freqtrade-manager:latest-pi"
+else
+    DOCKER_TAG="ph3nol/freqtrade-manager:latest"
 fi
 
 if [ -t 1 ]; then
@@ -52,8 +59,7 @@ if [ -f "${SCRIPT_DIRECTORY}/composer.json" ]; then
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v ${BOT_CONFIG_DIRECTORY}:/config:rw \
         -v ${MANAGER_TMP_DIRECTORY}/:/tmp/manager/:rw \
-        -v ${SCRIPT_DIRECTORY}:/app \
-        ph3nol/freqtrade-manager $*
+        ${DOCKER_TAG} $*
 # Staging (from Docker image)
 else
     docker run ${DOCKER_TTY_ARGS} --rm --name "freqtrade-manager-$(uuidgen)" --privileged=true \
@@ -62,5 +68,5 @@ else
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v ${BOT_CONFIG_DIRECTORY}:/config:rw \
         -v ${MANAGER_TMP_DIRECTORY}/:/tmp/manager/:rw \
-        ph3nol/freqtrade-manager $*
+        ${DOCKER_TAG} $*
 fi

--- a/docker/freqtrade-ui/Dockerfile
+++ b/docker/freqtrade-ui/Dockerfile
@@ -1,20 +1,28 @@
-FROM node:15.8.0-alpine as ui-builder
+FROM node:16.1.0-alpine3.12 as ui-builder
 
 RUN mkdir /app
 
-RUN wget --quiet https://github.com/freqtrade/frequi/archive/0.0.4.tar.gz -O /tmp/ui.tar.gz \
+RUN wget --quiet https://github.com/freqtrade/frequi/archive/refs/tags/0.0.6.tar.gz -O /tmp/ui.tar.gz \
     && tar xf /tmp/ui.tar.gz -C /app --strip 1 \
     && rm /tmp/ui.tar.gz
 
 WORKDIR /app
 
-RUN yarn
+# ENV PATH /usr/src/app/node_modules/.bin:$PATH
+
+#COPY package.json /app/package.json
+#COPY yarn.lock /app/yarn.lock
+
+RUN apk add --update --no-cache python3 g++ make\
+    && yarn \
+    && apk del python3 g++ make
+
 RUN yarn global add @vue/cli
 
 COPY . /app
 RUN yarn build
 
-FROM nginx:1.19.6-alpine
+FROM nginx:1.19.10-alpine
 COPY  --from=ui-builder /app/dist /etc/nginx/html
 COPY  --from=ui-builder /app/nginx.conf /etc/nginx/nginx.conf
 EXPOSE 80

--- a/docker/freqtrade_pi/Dockerfile
+++ b/docker/freqtrade_pi/Dockerfile
@@ -1,0 +1,7 @@
+FROM freqtradeorg/freqtrade:stable_pi
+
+RUN pip install --upgrade pip
+
+RUN pip install -U -r requirements-plot.txt
+RUN pip install technical
+RUN pip install TA-Lib

--- a/docker/manager/Dockerfile
+++ b/docker/manager/Dockerfile
@@ -1,4 +1,7 @@
-FROM php:7.4-cli-alpine
+# As of 2021-05-06, underlying alpine 3.13 arm image throws ssl verify error on Raspberry Pi
+# https://raspberrypi.stackexchange.com/questions/123675/certificate-problems-on-docker-image-for-rpi-alpine
+#FROM php:7.4-cli-alpine
+FROM php:7.4-cli-alpine3.12
 
 RUN apk update \
     && apk upgrade --available \
@@ -15,7 +18,7 @@ COPY composer.lock /app/composer.lock
 
 WORKDIR /app
 
-RUN composer install --prefer-dist --no-dev --no-scripts --no-progress --no-suggest; \
+RUN composer install --prefer-dist --no-dev --no-scripts --no-progress; \
     composer clear-cache
 
 RUN set -eux; \

--- a/install
+++ b/install
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 
@@ -8,9 +8,17 @@ echo "▶️  Preparing..."
 [ -d /tmp/freqtrade-manager/install/trading-bot ] || mkdir /tmp/freqtrade-manager/install/trading-bot
 
 echo "▶️  Downloading some required Docker images (wait some seconds/minutes while downloading)..."
-docker pull --quiet ph3nol/freqtrade:latest
-docker pull --quiet ph3nol/freqtrade-ui:latest
-docker pull --quiet ph3nol/freqtrade-manager:latest
+arch=`uname -m`
+if [ $arch = 'armv7l' ]; then
+    echo "▶️  Raspberry Pi detected. Fetching freqtrade_pi..."
+    docker pull --quiet ph3nol/freqtrade:latest-pi
+    docker pull --quiet ph3nol/freqtrade-ui:latest-pi
+    docker pull --quiet ph3nol/freqtrade-manager:latest-pi
+else
+    docker pull --quiet ph3nol/freqtrade:latest
+    docker pull --quiet ph3nol/freqtrade-ui:latest
+    docker pull --quiet ph3nol/freqtrade-manager:latest
+fi
 
 echo "▶️  Downloading/Installing Trading Bot..."
 if [ -d "/usr/local/bin" ]; then

--- a/src/Manager/App/Manager.php
+++ b/src/Manager/App/Manager.php
@@ -99,6 +99,8 @@ class Manager
                 return $behaviourData ?? [];
             }, $instanceBehaviours);
 
+            $dockerCoreImage = 
+
             $instance = Instance::create(
                 $instanceSlug,
                 $instancePayload['strategy'],
@@ -134,8 +136,15 @@ class Manager
 
     private function getDefaultParametersFromInstance(): array
     {
+        $tag_suffix = "";
+        if(php_uname("m") == "armv7l")
+            $tag_suffix = "-pi";
         return [
             'tradingHours' => [],
+            'docker' => [
+                'core_image' => sprintf('ph3nol/freqtrade:latest%s', $tag_suffix),
+                'ui_image' => 'ph3nol/freqtrade-ui:latest'
+            ]
         ];
     }
 

--- a/src/Manager/Domain/Instance.php
+++ b/src/Manager/Domain/Instance.php
@@ -156,9 +156,19 @@ class Instance
         return sprintf('trading-bot-%s-core', $this->slug);
     }
 
+    public function getDockerCoreImageName(): string
+    {
+        return $this->parameters['docker']['core_image'];
+    }
+
     public function getDockerUIInstanceName(): string
     {
         return sprintf('trading-bot-%s-ui', $this->slug);
+    }
+
+    public function getDockerUIImageName(): string
+    {
+        return $this->parameters['docker']['ui_image'];
     }
 
     public function hasBehaviour(BehaviourInterface $behaviour): bool

--- a/src/Manager/Infra/Process/InstanceProcess.php
+++ b/src/Manager/Infra/Process/InstanceProcess.php
@@ -28,7 +28,7 @@ class InstanceProcess
             sprintf('--volume %s:/freqtrade/tradesv3.dryrun.sqlite:rw', $instance->files['host']['db_dry_run']),
             sprintf('--volume %s:/freqtrade/tradesv3.sqlite:rw', $instance->files['host']['db_production']),
             sprintf('--publish %d:8080/tcp', $instance->parameters['ports']['api']),
-            'ph3nol/freqtrade:latest',
+            sprintf('%s', $instance->getDockerCoreImageName()),
             'trade --config /freqtrade/config.json',
             '--logfile /freqtrade/freqtrade.log',
             '--strategy-path /freqtrade',

--- a/src/Manager/Infra/Process/InstanceUIProcess.php
+++ b/src/Manager/Infra/Process/InstanceUIProcess.php
@@ -20,7 +20,7 @@ class InstanceUIProcess
             '--volume /etc/localtime:/etc/localtime:ro',
             sprintf('-v /tmp/freqtrade-manager/resources/scripts/ui-instance-entrypoint.sh:/docker-entrypoint.d/100-ui-instance-entrypoint.sh:ro'),
             sprintf('--publish %d:80/tcp', $instance->parameters['ports']['ui']),
-            'ph3nol/freqtrade-ui:latest',
+            sprintf('%s', $instance->getDockerUIImageName()),
         ];
 
         return trim(Process::processCommandLine(implode(' ', $processCommand)));


### PR DESCRIPTION
This change adds two basic features:
- The ability to configure the Docker images to be used for Core and UI containers via manager.yml (should also address #8)
- Automatic support for Raspberry Pi (4/Armv7)

I was mostly able to just update the existing Dockerfiles (Manager and UI), however freqtrade does currently not supply multiarch images for freqtrade, so theres a new one for the rPi variation of the "Core" container.

The default is still your tag of the image, nothing changed there.